### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ sudo sshfs -o allow_other,defer_permissions,IdentityFile=./lrpi_id_rsa lush@xxx.
 Run dev code inside a running Dockerised player (only works on a 'Pi!):
 
 ```
-sudo docker run -it --rm --network host -p 80:80 \
+sudo docker run --env MENU_DMX_VAL="255,172,36" --env NUM_DMX_CHANNELS=192 -it --rm --network host -p 80:80 \
 -v /home/lush/lrpi_player/flask:/opt/code/flask \
 -v /opt/vc:/opt/vc \
 -v /media/usb:/media/usb \

--- a/flask/Lighting.py
+++ b/flask/Lighting.py
@@ -23,7 +23,8 @@ LIGHTING_MSGS = True
 
 
 # dmx
-
+MENU_DMX_VAL = os.environ.get("MENU_DMX_VAL", None)
+NUM_DMX_CHANNELS = os.environ.get("NUM_DMX_CHANNELS", None)
 HOST = os.environ.get("BRICKD_HOST", "127.0.0.1")
 PORT = 4223
 
@@ -150,16 +151,27 @@ class LushRoomsLighting():
                     if tf[1] == 285: # DMX Bricklet
                         if dmxcount == 0:
                             # channels = int((int(MAX_BRIGHTNESS)/255.0)*ones(512)*255)
-                            self.dmx.write_frame([ int(0.65*MAX_BRIGHTNESS),
-                                                   int(0.40*MAX_BRIGHTNESS),
-                                                   int(0.40*MAX_BRIGHTNESS),
-                                                   int(0.40*MAX_BRIGHTNESS),
-                                                   int(0.40*MAX_BRIGHTNESS),
-                                                   int(0.40*MAX_BRIGHTNESS),
-                                                   int(0.40*MAX_BRIGHTNESS),
-                                                   int(0.40*MAX_BRIGHTNESS),
-                                                   int(0.40*MAX_BRIGHTNESS),
-                                                   0,0,0,int(0.40*MAX_BRIGHTNESS) ])
+                            if (MENU_DMX_VAL is not None and NUM_DMX_CHANNELS is not None):
+                                print('menu values: ', MENU_DMX_VAL)
+                                print('number of DMX channels: ', NUM_DMX_CHANNELS)
+                                frame_arr = []
+                                menu_val_arr = MENU_DMX_VAL.split(",")
+                                menu_val_arr = [int(i) for i in menu_val_arr]
+                                for i in range(int(int(NUM_DMX_CHANNELS)/3)):
+                                    frame_arr += menu_val_arr
+                                self.dmx.write_frame(frame_arr)
+                            else:
+                                print('Resetting DMX...')
+                                self.dmx.write_frame([ int(0.65*MAX_BRIGHTNESS),
+                                                    int(0.40*MAX_BRIGHTNESS),
+                                                    int(0.40*MAX_BRIGHTNESS),
+                                                    int(0.40*MAX_BRIGHTNESS),
+                                                    int(0.40*MAX_BRIGHTNESS),
+                                                    int(0.40*MAX_BRIGHTNESS),
+                                                    int(0.40*MAX_BRIGHTNESS),
+                                                    int(0.40*MAX_BRIGHTNESS),
+                                                    int(0.40*MAX_BRIGHTNESS),
+                                                    0,0,0,int(0.40*MAX_BRIGHTNESS) ])
                         dmxcount += 1
                     if LIGHTING_MSGS:
                         print('dmxcount: ', dmxcount)


### PR DESCRIPTION
Added the option to set an RGB value when `resetDMX()` is called (normally when going back to the treatment select page on the front end) to an arbitrary number of DMX RGB channels. 

...it won't work with RGBW